### PR TITLE
Modifications made to AADL Event Port (direct) implementation.

### DIFF
--- a/apps/aadl-event-direct/aadl-event-direct.camkes
+++ b/apps/aadl-event-direct/aadl-event-direct.camkes
@@ -20,14 +20,14 @@ assembly {
         component Receiver receiver;
         component Sender sender;
 
-	connection seL4Notification sre(from sender.e, to receiver.e);
-	connection seL4SharedData srcounter(from sender.counter, to receiver.counter);
+        // AADL Event Port connection representation from sender.ep1_out to reciever.ep1_in
+	connection seL4Notification epc1_event(from sender.ep1_out_SendEvent, to receiver.ep1_in_SendEvent);
+	connection seL4SharedData epc1_coutner(from sender.ep1_out_counter, to receiver.ep1_in_counter);
     }
     configuration {
 
-        sender.counter_access = "W";
-        receiver.counter_access = "R";
-
+        sender.ep1_out_counter_access = "W";
+        receiver.ep1_in_counter_access = "R";
 
         sender._priority = 50;
         receiver._priority = 50;

--- a/apps/aadl-event-direct/components/Receiver/Receiver.camkes
+++ b/apps/aadl-event-direct/components/Receiver/Receiver.camkes
@@ -10,12 +10,18 @@
  * @TAG(DATA61_BSD)
  */
 
+/*
+ * Copyright 2019 Adventium Labs.
+ * Modifications made to original.
+ */
 
 component Receiver {
     //include "../../interfaces/counter.h";
     include <counter.h>;
     control;
-    consumes ReceiveEvent e;
-    dataport int_t counter;
+
+    // ep1_in - AADL Event Port (in) representation
+    consumes SendEvent ep1_in_SendEvent;
+    dataport counter_t ep1_in_counter;
 }
 

--- a/apps/aadl-event-direct/components/Receiver/src/receiver.c
+++ b/apps/aadl-event-direct/components/Receiver/src/receiver.c
@@ -10,36 +10,108 @@
  * @TAG(DATA61_BSD)
  */
 
+/*
+ * Copyright 2019 Adventium Labs.
+ * Modifications made to original.
+ */
+
 #include <camkes.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <counter.h>
 
-int num_events = 0;
-int my_counter = 0;
+//------------------------------------------------------------------------------
+// Implemention of AADL Input Event Port named "ep1_in"
+// Three styles: polling, waiting and callback.
+//
+// Callback would typicaly be avoid for safety critical systems. It is harder
+// to analyze since the callback handler is run on some arbitrary thread.
 
-int aadl_get_events(void) {
-    int dif = 0;
-    int the_counter = *counter;
-    if (my_counter <= the_counter) {
-        dif = the_counter - my_counter;
-        my_counter = the_counter;
+counter_t ep1_in_recv_counter = 0;
+
+// Assumption: only one thread is calling this and/or reading ep1_in_recv_counter.
+bool ep1_in_aadl_event_poll(void) {
+    counter_t the_counter = *ep1_in_counter;
+    // Acquire memory fence - ensure preceding read occurs before any subsequent read or write
+    ep1_in_counter_acquire();
+    if ( the_counter != ep1_in_recv_counter ) {
+        // NOTE: Counters can wrap, so we must use != above instead of >.  If
+        // it ever happens that reciever falls so far behind that the send
+        // counter wraps all the way around, the reciever will loose all those
+        // events without knowing it. Since the counter is large this would be
+        // a very exceptional situation where something has gone very wrong
+        // with the receiver.
+        ++ep1_in_recv_counter;
+        return true;
     }
-    return dif;
-}
-void aadl_event_port_handler(void) {
-    printf("Receiver received event %d\n", num_events);
-    num_events++;
+    return false;
 }
 
-static void handler(void *v) {
-    
-    int ne = aadl_get_events();
-    for (int i = 0; i < ne; i++) {
-    	aadl_event_port_handler();
+void ep1_in_aadl_event_wait(void) {
+    while (!ep1_in_aadl_event_poll()) {
+        ep1_in_SendEvent_wait();
     }
-    while (! e_reg_callback(&handler, NULL));
+}
+
+void ep1_in_aadl_event_port_handler(void) {
+    printf("%s: received event %" PRIuMAX "\n", get_instance_name(), ep1_in_recv_counter);
+}
+
+static void ep1_in_handler(void *v) {
+    // Handle ALL events that have been queued up
+    while (ep1_in_aadl_event_poll()) {
+    	ep1_in_aadl_event_port_handler();
+    }
+    while (! ep1_in_SendEvent_reg_callback(&ep1_in_handler, NULL));
+}
+
+//------------------------------------------------------------------------------
+// Testing
+
+int run_callback(void) {
+    return ep1_in_SendEvent_reg_callback(&ep1_in_handler, NULL);
+}
+
+void run_wait(void) {
+    while (true) {
+        ep1_in_aadl_event_wait();
+        printf("%s: received event %" PRIuMAX "\n", get_instance_name(), ep1_in_recv_counter);
+    }
+}
+
+void run_poll(void) {
+    while (1) {
+
+        // Busy loop slow things down
+        for(unsigned int j = 0; j < 80000; ++j){
+            seL4_Yield();
+        }
+
+        // Random number of polls for testing
+        int n = (random() % 10);
+        for(unsigned int j = 0; j < n; ++j){
+            bool eventReceived = ep1_in_aadl_event_poll();
+            if (eventReceived) {
+                printf("%s: received event %" PRIuMAX "\n", get_instance_name(), ep1_in_recv_counter);
+            } else {
+                printf("%s: received no events\n", get_instance_name());
+            }
+        }
+
+    }
+
 }
 
 int run(void) {
-    return e_reg_callback(&handler, NULL);
+    // Pick one receive style to test.
+    //return run_callback();
+    //run_wait();
+    run_poll();
 }
 
+// Emacs Declarations
+// Local Variables:
+// mode: c
+// c-basic-offset: 4
+// indent-tabs-mode: nil
+// End:              

--- a/apps/aadl-event-direct/components/Sender/Sender.camkes
+++ b/apps/aadl-event-direct/components/Sender/Sender.camkes
@@ -10,11 +10,17 @@
  * @TAG(DATA61_BSD)
  */
 
+/*
+ * Copyright 2019 Adventium Labs.
+ * Modifications made to original.
+ */
 
 component Sender {
     include <counter.h>;
     control;
-    emits ReceiveEvent e;
-    dataport int_t counter;
+
+    // ep1_out - AADL Event Port (out) representation
+    emits SendEvent ep1_out_SendEvent;
+    dataport counter_t ep1_out_counter;
 }
 

--- a/apps/aadl-event-direct/interfaces/counter.h
+++ b/apps/aadl-event-direct/interfaces/counter.h
@@ -1,3 +1,5 @@
 #pragma once
 
-typedef int int_t;
+#include <stdint.h>
+
+typedef _Atomic uintmax_t counter_t;


### PR DESCRIPTION
- Added some documentation
- Naming changes to make it clear what needs to be generated for each AADL Event Port.
- Declared counter atomic to make sure value is coherent whenever read.
- Added memory fence declarations to make sure memory is coherent. This might not be necessary since ether is only a single atomic counter.
- Added polling and wait style receive mechanism in addition to the callback mechanism.  Safety critical systems would typically avoid using callback mechanisms.
- Added a bit more testing code