### PR TITLE
New AADL Event Data Port implementation and some other minor tweaks 

### DIFF
--- a/apps/aadl-event-direct/CMakeLists.txt
+++ b/apps/aadl-event-direct/CMakeLists.txt
@@ -3,11 +3,14 @@
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)
 # ABN 41 687 119 230.
 #
+# Copyright 2019 Adventium Labs
+# Modifications made to original
+#
 # This software may be distributed and modified according to the terms of
 # the BSD 2-Clause license. Note that NO WARRANTY is provided.
 # See "LICENSE_BSD2.txt" for details.
 #
-# @TAG(DATA61_BSD)
+# @TAG(DATA61_Adventium_BSD)
 #
 
 cmake_minimum_required(VERSION 3.7.2)

--- a/apps/aadl-event-direct/README
+++ b/apps/aadl-event-direct/README
@@ -3,15 +3,28 @@
      Commonwealth Scientific and Industrial Research Organisation (CSIRO)
      ABN 41 687 119 230.
 
+     Copyright 2019 Adventium Labs
+     Modifications made to original
+
      This software may be distributed and modified according to the terms of
      the BSD 2-Clause license. Note that NO WARRANTY is provided.
      See "LICENSE_BSD2.txt" for details.
 
-     @TAG(DATA61_BSD)
+     @TAG(DATA61_Adventium_BSD)
 -->
 #
 
-This application demonstrates the of a counter to implement AADL
-event port semantics.  This provides one-way data flow from the 
-sender to the receiver.
+This application demonstrates the use of a counter to implement AADL event
+port semantics.  This provides one-way data flow from the sender to the
+receiver without loss of events. The implementation supports a single producer
+and any number of receivers. Three styles of recover are supported:
+
+polling - Non-blocking check for an event.  This is intended to be used in
+cases where there is some natural wait time for poll interval such as a periodic
+wait. This is the typical style used for safety critical realtime systems.
+
+wait - Blocking wait for an event.
+
+callback - When an event is sent, the receiver calls a callback function on some
+arbitrary thread.
 

--- a/apps/aadl-event-direct/aadl-event-direct.camkes
+++ b/apps/aadl-event-direct/aadl-event-direct.camkes
@@ -3,16 +3,14 @@
  * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
  * ABN 41 687 119 230.
  *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
  * This software may be distributed and modified according to the terms of
  * the BSD 2-Clause license. Note that NO WARRANTY is provided.
  * See "LICENSE_BSD2.txt" for details.
  *
- * @TAG(DATA61_BSD)
- */
-
-/*
- * Copyright 2019 Adventium Labs.
- * Modifications made to original.
+ * @TAG(DATA61_Adventium_BSD)
  */
 
 import <std_connector.camkes>;

--- a/apps/aadl-event-direct/aadl-event-direct.camkes
+++ b/apps/aadl-event-direct/aadl-event-direct.camkes
@@ -10,6 +10,11 @@
  * @TAG(DATA61_BSD)
  */
 
+/*
+ * Copyright 2019 Adventium Labs.
+ * Modifications made to original.
+ */
+
 import <std_connector.camkes>;
 
 import "components/Receiver/Receiver.camkes";

--- a/apps/aadl-event-direct/components/Receiver/CMakeLists.txt
+++ b/apps/aadl-event-direct/components/Receiver/CMakeLists.txt
@@ -3,11 +3,14 @@
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)
 # ABN 41 687 119 230.
 #
+# Copyright 2019 Adventium Labs
+# Modifications made to original
+#
 # This software may be distributed and modified according to the terms of
 # the BSD 2-Clause license. Note that NO WARRANTY is provided.
 # See "LICENSE_BSD2.txt" for details.
 #
-# @TAG(DATA61_BSD)
+# @TAG(DATA61_Adventium_BSD)
 #
 
 cmake_minimum_required(VERSION 3.7.2)

--- a/apps/aadl-event-direct/components/Receiver/Receiver.camkes
+++ b/apps/aadl-event-direct/components/Receiver/Receiver.camkes
@@ -3,16 +3,14 @@
  * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
  * ABN 41 687 119 230.
  *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
  * This software may be distributed and modified according to the terms of
  * the BSD 2-Clause license. Note that NO WARRANTY is provided.
  * See "LICENSE_BSD2.txt" for details.
  *
- * @TAG(DATA61_BSD)
- */
-
-/*
- * Copyright 2019 Adventium Labs.
- * Modifications made to original.
+ * @TAG(DATA61_Adventium_BSD)
  */
 
 component Receiver {

--- a/apps/aadl-event-direct/components/Receiver/Receiver.camkes
+++ b/apps/aadl-event-direct/components/Receiver/Receiver.camkes
@@ -21,6 +21,7 @@ component Receiver {
     control;
 
     // ep1_in - AADL Event Port (in) representation
+    // NOTE: If we only need polling style receivers, we can get rid of the SendEvent
     consumes SendEvent ep1_in_SendEvent;
     dataport counter_t ep1_in_counter;
 }

--- a/apps/aadl-event-direct/components/Receiver/src/receiver.c
+++ b/apps/aadl-event-direct/components/Receiver/src/receiver.c
@@ -26,6 +26,8 @@
 //
 // Callback would typicaly be avoid for safety critical systems. It is harder
 // to analyze since the callback handler is run on some arbitrary thread.
+//
+// NOTE: If we only need polling style recivers, we can get rid of the SendEvent
 
 counter_t ep1_in_recv_counter = 0;
 
@@ -66,7 +68,7 @@ static void ep1_in_handler(void *v) {
 }
 
 //------------------------------------------------------------------------------
-// Testing
+// Testing - Three tests for the different styles: callback, wait and poll.
 
 int run_callback(void) {
     return ep1_in_SendEvent_reg_callback(&ep1_in_handler, NULL);

--- a/apps/aadl-event-direct/components/Receiver/src/receiver.c
+++ b/apps/aadl-event-direct/components/Receiver/src/receiver.c
@@ -3,16 +3,14 @@
  * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
  * ABN 41 687 119 230.
  *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
  * This software may be distributed and modified according to the terms of
  * the BSD 2-Clause license. Note that NO WARRANTY is provided.
  * See "LICENSE_BSD2.txt" for details.
  *
- * @TAG(DATA61_BSD)
- */
-
-/*
- * Copyright 2019 Adventium Labs.
- * Modifications made to original.
+ * @TAG(DATA61_Adventium_BSD)
  */
 
 #include <camkes.h>

--- a/apps/aadl-event-direct/components/Sender/CMakeLists.txt
+++ b/apps/aadl-event-direct/components/Sender/CMakeLists.txt
@@ -3,11 +3,14 @@
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)
 # ABN 41 687 119 230.
 #
+# Copyright 2019 Adventium Labs
+# Modifications made to original
+#
 # This software may be distributed and modified according to the terms of
 # the BSD 2-Clause license. Note that NO WARRANTY is provided.
 # See "LICENSE_BSD2.txt" for details.
 #
-# @TAG(DATA61_BSD)
+# @TAG(DATA61_Adventium_BSD)
 #
 
 cmake_minimum_required(VERSION 3.7.2)

--- a/apps/aadl-event-direct/components/Sender/Sender.camkes
+++ b/apps/aadl-event-direct/components/Sender/Sender.camkes
@@ -20,6 +20,7 @@ component Sender {
     control;
 
     // ep1_out - AADL Event Port (out) representation
+    // NOTE: If we only need polling style receivers, we can get rid of the SendEvent
     emits SendEvent ep1_out_SendEvent;
     dataport counter_t ep1_out_counter;
 }

--- a/apps/aadl-event-direct/components/Sender/Sender.camkes
+++ b/apps/aadl-event-direct/components/Sender/Sender.camkes
@@ -3,16 +3,14 @@
  * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
  * ABN 41 687 119 230.
  *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
  * This software may be distributed and modified according to the terms of
  * the BSD 2-Clause license. Note that NO WARRANTY is provided.
  * See "LICENSE_BSD2.txt" for details.
  *
- * @TAG(DATA61_BSD)
- */
-
-/*
- * Copyright 2019 Adventium Labs.
- * Modifications made to original.
+ * @TAG(DATA61_Adventium_BSD)
  */
 
 component Sender {

--- a/apps/aadl-event-direct/components/Sender/src/sender.c
+++ b/apps/aadl-event-direct/components/Sender/src/sender.c
@@ -3,16 +3,14 @@
  * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
  * ABN 41 687 119 230.
  *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
  * This software may be distributed and modified according to the terms of
  * the BSD 2-Clause license. Note that NO WARRANTY is provided.
  * See "LICENSE_BSD2.txt" for details.
  *
- * @TAG(DATA61_BSD)
- */
-
-/*
- * Copyright 2019 Adventium Labs.
- * Modifications made to original.
+ * @TAG(DATA61_Adventium_BSD)
  */
 
 #include <camkes.h>

--- a/apps/aadl-event-direct/components/Sender/src/sender.c
+++ b/apps/aadl-event-direct/components/Sender/src/sender.c
@@ -31,6 +31,7 @@ int ep1_out_aadl_send_event(void) {
     ++(*ep1_out_counter);
     // Release memory fence - ensure subsequent write occurs after any preceeding read or write
     ep1_out_counter_release();
+    // NOTE: If we only need polling style recivers, we can get rid of the SendEvent
     ep1_out_SendEvent_emit();
     return 0;
 }

--- a/apps/aadl-eventdata-direct-new/CMakeLists.txt
+++ b/apps/aadl-eventdata-direct-new/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2018, Data61
+# Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+# ABN 41 687 119 230.
+#
+# Copyright 2019 Adventium Labs
+# Modifications made to original
+#
+# This software may be distributed and modified according to the terms of
+# the BSD 2-Clause license. Note that NO WARRANTY is provided.
+# See "LICENSE_BSD2.txt" for details.
+#
+# @TAG(DATA61_Adventium_BSD)
+#
+
+cmake_minimum_required(VERSION 3.7.2)
+
+project(aadl-eventdata-direct C)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/components/Receiver)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/components/Sender)
+
+DeclareCAmkESRootserver(aadl-eventdata-direct.camkes)

--- a/apps/aadl-eventdata-direct-new/README
+++ b/apps/aadl-eventdata-direct-new/README
@@ -1,0 +1,47 @@
+<!--
+     Copyright 2017, Data61
+     Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+     ABN 41 687 119 230.
+
+     Copyright 2019 Adventium Labs
+     Modifications made to original
+
+     This software may be distributed and modified according to the terms of
+     the BSD 2-Clause license. Note that NO WARRANTY is provided.
+     See "LICENSE_BSD2.txt" for details.
+
+     @TAG(DATA61_Adventium_BSD)
+-->
+
+AADL Event Data Port Example
+
+This application demonstrates the use of a counter and a circular queue to
+implement AADL Event Data Port semantics. This provides one-way data flow from
+the sender to the receiver preserving order of event data. Data can be lost
+when the buffer fills and receivers are not reading fast enough.  Receivers
+will be able to detect number of lost event data items. The implementation
+supports a single producer and any number of receivers. Three styles of
+receiver are supported:
+
+  poll - Non-blocking check for an event.  This is intended to be used in
+  cases where there is some natural wait time for poll interval such as a periodic
+  wait. This is the typical style used for safety critical realtime systems.
+
+  wait - Blocking wait for an event.
+
+  callback - When an event is sent, the receiver calls a callback function on some
+  arbitrary thread.
+
+This implementation assume the following AADL properties on the port:
+
+  Fan_out_policy => Broadcast;
+  Overflow_Handling_protocol => DropOldest;
+  Queue_Processing_Protocol => FIFO;
+  Queue_Size => <aadlinteger>;
+
+NOTE: With a little more work this implementation could be generalized to handle
+AADL event and data ports as well.
+
+  event - Just use the numSent and numRecv counters. Disable queue.
+
+  data - Set QUEUE_SIZE to 2 (ie a double buffer).

--- a/apps/aadl-eventdata-direct-new/aadl-eventdata-direct.camkes
+++ b/apps/aadl-eventdata-direct-new/aadl-eventdata-direct.camkes
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+import <std_connector.camkes>;
+
+import "components/Receiver/Receiver.camkes";
+import "components/Sender/Sender.camkes";
+
+assembly {
+    composition {
+        component Receiver receiver;
+        component Sender sender;
+
+        // AADL Event Data Port connection representation from sender.p1_out to reciever.p1_in
+	connection seL4Notification pc1_event(from sender.p1_out_SendEvent, to receiver.p1_in_SendEvent);
+	connection seL4SharedData pc1_queue(from sender.p1_out_queue, to receiver.p1_in_queue);
+    }
+    configuration {
+
+        sender.p1_out_queue_access = "W";
+        receiver.p1_in_queue_access = "R";
+
+        sender._priority = 50;
+        receiver._priority = 50;
+    }
+}
+

--- a/apps/aadl-eventdata-direct-new/components/Receiver/CMakeLists.txt
+++ b/apps/aadl-eventdata-direct-new/components/Receiver/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2018, Data61
+# Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+# ABN 41 687 119 230.
+#
+# Copyright 2019 Adventium Labs
+# Modifications made to original
+#
+# This software may be distributed and modified according to the terms of
+# the BSD 2-Clause license. Note that NO WARRANTY is provided.
+# See "LICENSE_BSD2.txt" for details.
+#
+# @TAG(DATA61_Adventium_BSD)
+#
+
+cmake_minimum_required(VERSION 3.7.2)
+
+project(ComponentReceiver C)
+
+DeclareCAmkESComponent(Receiver
+    SOURCES src/receiver.c src/queue.c
+    INCLUDES include
+)

--- a/apps/aadl-eventdata-direct-new/components/Receiver/Receiver.camkes
+++ b/apps/aadl-eventdata-direct-new/components/Receiver/Receiver.camkes
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+component Receiver {
+    include <queue.h>;
+    control;
+
+    // p1_in - AADL Event Data Port (in) representation
+    // NOTE: If we only need polling style receivers, we can get rid of the SendEvent
+    consumes SendEvent p1_in_SendEvent;
+    dataport queue_t p1_in_queue;
+}
+

--- a/apps/aadl-eventdata-direct-new/components/Receiver/include
+++ b/apps/aadl-eventdata-direct-new/components/Receiver/include
@@ -1,0 +1,1 @@
+../../interfaces/

--- a/apps/aadl-eventdata-direct-new/components/Receiver/src/queue.c
+++ b/apps/aadl-eventdata-direct-new/components/Receiver/src/queue.c
@@ -1,0 +1,1 @@
+../../../interfaces/queue.c

--- a/apps/aadl-eventdata-direct-new/components/Receiver/src/receiver.c
+++ b/apps/aadl-eventdata-direct-new/components/Receiver/src/receiver.c
@@ -73,7 +73,6 @@ void run_poll(void) {
     counter_t numDropped;
     data_t data;
 
-    recv_queue_init(&recvQueue, p1_in_queue);
     while (true) {
 
         // Busy loop to wait a bit and slow things down
@@ -100,7 +99,6 @@ void run_wait(void) {
     counter_t numDropped;
     data_t data;
 
-    recv_queue_init(&recvQueue, p1_in_queue);
     while (true) {
         p1_in_aadl_event_data_wait(&numDropped, &data);
         p1_in_aadl_event_data_receive(numDropped, &data);
@@ -115,8 +113,11 @@ void run_wait(void) {
 }
 
 int run_callback(void) {
-    recv_queue_init(&recvQueue, p1_in_queue);
-    return p1_in_SendEvent_reg_callback(&p1_in_handler, NULL);
+     return p1_in_SendEvent_reg_callback(&p1_in_handler, NULL);
+}
+
+void post_init(void) {
+   recv_queue_init(&recvQueue, p1_in_queue);
 }
 
 int run(void) {

--- a/apps/aadl-eventdata-direct-new/components/Receiver/src/receiver.c
+++ b/apps/aadl-eventdata-direct-new/components/Receiver/src/receiver.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+#include <camkes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <counter.h>
+#include <data.h>
+#include <queue.h>
+
+//------------------------------------------------------------------------------
+// User specified input data receive handler for AADL Input Event Data Port (in) named
+// "p1_in".
+
+void p1_in_aadl_event_data_receive(counter_t numDropped, data_t *data) {
+    printf("%s: received: %d  numDropped: %" PRIcounter "\n", get_instance_name(), data->x, numDropped);
+}
+
+//------------------------------------------------------------------------------
+// Implementation of AADL Input Event Data Port (in) named "p1_in"
+// Three styles: poll, wait and callback.
+//
+// Callback would typically be avoid for safety critical systems. It is harder
+// to analyze since the callback handler is run on some arbitrary thread.
+//
+// NOTE: If we only need polling style receivers, we can get rid of SendEvent
+
+recv_queue_t recvQueue;
+
+// Assumption: only one thread is calling this and/or reading p1_in_recv_counter.
+bool p1_in_aadl_event_data_poll(counter_t *numDropped, data_t *data) {
+    return queue_dequeue(&recvQueue, numDropped, data);
+}
+
+void p1_in_aadl_event_data_wait(counter_t *numDropped, data_t *data) {
+    while (!p1_in_aadl_event_data_poll(numDropped, data)) {
+        p1_in_SendEvent_wait();
+    }
+}
+
+static void p1_in_handler(void *v) {
+    counter_t numDropped;
+    data_t data;
+
+    // Handle ALL events that have been queued up
+    while (p1_in_aadl_event_data_poll(&numDropped, &data)) {
+    	p1_in_aadl_event_data_receive(numDropped, &data);
+    }
+    while (! p1_in_SendEvent_reg_callback(&p1_in_handler, NULL));
+}
+
+//------------------------------------------------------------------------------
+// Testing - Three tests for the different styles: poll, wait and callback.
+//
+// NOTE: The constants in the tests were chosen to cause a variety of
+// situations at runtime including dropped packets and no data
+// available. These numbers may not cause the same variety of behaviour in
+// different test environments.
+
+void run_poll(void) {
+    counter_t numDropped;
+    data_t data;
+
+    recv_queue_init(&recvQueue, p1_in_queue);
+    while (true) {
+
+        // Busy loop to wait a bit and slow things down
+        for(unsigned int j = 0; j < 80000; ++j){
+            seL4_Yield();
+        }
+
+        // Random number of polls for testing
+        int n = (random() % 10);
+        for(unsigned int j = 0; j < n; ++j){
+            bool dataReceived = p1_in_aadl_event_data_poll(&numDropped, &data);
+            if (dataReceived) {
+                p1_in_aadl_event_data_receive(numDropped, &data);
+            } else {
+                printf("%s: received nothing\n", get_instance_name());
+            }
+        }
+
+    }
+
+}
+
+void run_wait(void) {
+    counter_t numDropped;
+    data_t data;
+
+    recv_queue_init(&recvQueue, p1_in_queue);
+    while (true) {
+        p1_in_aadl_event_data_wait(&numDropped, &data);
+        p1_in_aadl_event_data_receive(numDropped, &data);
+
+        // Busy loop to wait a bit and slow things down randomly
+        int n = (random() % 10) * 5000;
+        for(unsigned int j = 0; j < n; ++j){
+            seL4_Yield();
+        }
+
+    }
+}
+
+int run_callback(void) {
+    recv_queue_init(&recvQueue, p1_in_queue);
+    return p1_in_SendEvent_reg_callback(&p1_in_handler, NULL);
+}
+
+int run(void) {
+    // Pick one receive style to test.
+    run_poll();
+    //run_wait();
+    //return run_callback();
+}
+
+// Emacs Declarations
+// Local Variables:
+// mode: c
+// c-basic-offset: 4
+// indent-tabs-mode: nil
+// End:              

--- a/apps/aadl-eventdata-direct-new/components/Sender/CMakeLists.txt
+++ b/apps/aadl-eventdata-direct-new/components/Sender/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2018, Data61
+# Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+# ABN 41 687 119 230.
+#
+# Copyright 2019 Adventium Labs
+# Modifications made to original
+#
+# This software may be distributed and modified according to the terms of
+# the BSD 2-Clause license. Note that NO WARRANTY is provided.
+# See "LICENSE_BSD2.txt" for details.
+#
+# @TAG(DATA61_Adventium_BSD)
+#
+
+cmake_minimum_required(VERSION 3.7.2)
+
+project(ComponentSender C)
+
+DeclareCAmkESComponent(Sender
+    SOURCES src/sender.c src/queue.c
+    INCLUDES include
+)

--- a/apps/aadl-eventdata-direct-new/components/Sender/Sender.camkes
+++ b/apps/aadl-eventdata-direct-new/components/Sender/Sender.camkes
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+component Sender {
+    include <queue.h>;
+    control;
+
+    // p1_out - AADL Event Data Port (out) representation
+    // NOTE: If we only need polling style receivers, we can get rid of the SendEvent
+    emits SendEvent p1_out_SendEvent;
+    dataport queue_t p1_out_queue;
+}
+

--- a/apps/aadl-eventdata-direct-new/components/Sender/include
+++ b/apps/aadl-eventdata-direct-new/components/Sender/include
@@ -1,0 +1,1 @@
+../../interfaces/

--- a/apps/aadl-eventdata-direct-new/components/Sender/src/queue.c
+++ b/apps/aadl-eventdata-direct-new/components/Sender/src/queue.c
@@ -1,0 +1,1 @@
+../../../interfaces/queue.c

--- a/apps/aadl-eventdata-direct-new/components/Sender/src/sender.c
+++ b/apps/aadl-eventdata-direct-new/components/Sender/src/sender.c
@@ -36,13 +36,15 @@ void p1_out_aadl_event_data_send(data_t *data) {
 //------------------------------------------------------------------------------
 // Testing
 
+void post_init(void) {
+    queue_init(p1_out_queue);
+}
+
 int run(void) {
 
     int i = 0;
     int err = 0;
     data_t data;
-
-    queue_init(p1_out_queue);
 
     while (1) {
 

--- a/apps/aadl-eventdata-direct-new/components/Sender/src/sender.c
+++ b/apps/aadl-eventdata-direct-new/components/Sender/src/sender.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+#include <camkes.h>
+#include <stdio.h>
+#include <string.h>
+#include <sel4/sel4.h>
+#include <stdlib.h>
+#include <counter.h>
+#include <data.h>
+#include <queue.h>
+
+//------------------------------------------------------------------------------
+// Implementation of AADL Input Event Data Port (out) named "p1_out"
+//
+// NOTE: If we only need polling style receivers, we can get rid of the SendEvent
+
+// Assumption: only one thread is calling this and/or reading p1_in_recv_counter.
+void p1_out_aadl_event_data_send(data_t *data) {
+    queue_enqueue(p1_out_queue, data);
+    p1_out_SendEvent_emit();
+}
+
+//------------------------------------------------------------------------------
+// Testing
+
+int run(void) {
+
+    int i = 0;
+    int err = 0;
+    data_t data;
+
+    queue_init(p1_out_queue);
+
+    while (1) {
+
+        // Busy loop to slow things down
+        for(unsigned int j = 0; j < 100000; ++j){
+            seL4_Yield();
+        }
+
+        // Send a random number of data elements
+        int n = (random() % 10);
+        for(unsigned int j = 0; j < n; ++j){
+            ++i;
+            // Stage data
+            data.x = i;
+            printf("%s: sending: %d\n", get_instance_name(), data.x);
+            // Send the data
+            p1_out_aadl_event_data_send(&data);          
+        }
+    }
+}
+
+// Emacs Declarations
+// Local Variables:
+// mode: c
+// c-basic-offset: 4
+// indent-tabs-mode: nil
+// End:              
+
+

--- a/apps/aadl-eventdata-direct-new/interfaces/counter.h
+++ b/apps/aadl-eventdata-direct-new/interfaces/counter.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+
+// Defs to allow easy changing of counter type. Keep these consistent!
+typedef uintmax_t counter_t;
+#define COUNTER_MAX UINTMAX_MAX
+#define PRIcounter PRIuMAX

--- a/apps/aadl-eventdata-direct-new/interfaces/data.h
+++ b/apps/aadl-eventdata-direct-new/interfaces/data.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// The event data port type. Sender and receiver type must match. Many ports can use the same type.
+// The data representation is independent of the queue representation.
+//
+// NOTE: data_t must define a type for which assignment will copy all the
+// data. For example, pointers do not work.
+typedef struct data {
+  int x;
+} data_t;
+

--- a/apps/aadl-eventdata-direct-new/interfaces/queue.c
+++ b/apps/aadl-eventdata-direct-new/interfaces/queue.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+#include <queue.h>
+#include <stdint.h>
+#include <stddef.h>
+
+//------------------------------------------------------------------------------
+// Sender API
+//
+// See queue.h for API documentation. Only implementation details are documented here.
+
+void queue_init(queue_t *queue) {
+  // NOOP for now. C's struct initialization is sufficient.  If we ever do need
+  // initialization logic, we may also need to synchronize with receiver
+  // startup.
+}
+
+void queue_enqueue(queue_t *queue, data_t *data) {
+  // Simple ring with one dirty element that will be written next. Only one
+  // writer, so no need for any synchronization. elt[queue->numSent %
+  // QUEUE_SIZE] is always considered dirty. So do not advance queue-NumSent
+  // till AFTER data is copied.
+  
+  size_t i = queue->numSent % QUEUE_SIZE;
+  queue->elt[i] = *data; // Copy data into queue
+  // Release memory fence - ensure that data write above completes BEFORE we advance queue->numSent
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+  ++(queue->numSent);
+}
+
+//------------------------------------------------------------------------------
+// Receiver API
+//
+// See queue.h for API documentation. Only implementation details are documented here.
+
+void recv_queue_init(recv_queue_t *recvQueue, queue_t *queue) {
+  recvQueue->numRecv = 0;
+  recvQueue->queue = queue;
+}
+
+bool queue_dequeue(recv_queue_t *recvQueue, counter_t *numDropped, data_t *data) {
+  counter_t *numRecv = &recvQueue->numRecv;
+  queue_t *queue = recvQueue->queue;
+  // Get a copy of numSent so we can see if it changes durring read
+  counter_t numSent = queue->numSent;
+  // Acquire memory fence - ensure read of queue->numSent BEFORE reading data
+  __atomic_thread_fence(__ATOMIC_ACQUIRE);
+  // How many new elements have been sent? Since we are using unsigned
+  // integers, this correctly computes the value as counters wrap.
+  counter_t numNew = numSent - *numRecv;
+  if (0 == numNew) {
+    // Queue is empty
+    return false;
+  }
+  // One element in the ring buffer is always considered dirty. Its the next
+  // element we will write.  It's not safe to read it until numSent has been
+  // incremented. Thus there are really only (QUEUE_SIZE - 1) elements in the
+  // queue.
+  *numDropped = (numNew <= QUEUE_SIZE - 1) ? 0 : numNew - QUEUE_SIZE + 1;
+  // Increment numRecv by *numDropped plus one for the element we are about to
+  // read.
+  *numRecv += *numDropped + 1;
+  counter_t numRemaining = numSent - *numRecv;
+  size_t i = (*numRecv - 1) % QUEUE_SIZE;
+  *data = queue->elt[i]; // Copy data
+  // Acquire memory fence - ensure read of data BEFORE reading queue->numSent again 
+  __atomic_thread_fence(__ATOMIC_ACQUIRE);
+  if (queue->numSent - *numRecv + 1 < QUEUE_SIZE) {
+    // Sender did not write element we were reading. Copied data is coherent.
+    return true;
+  } else {
+    // Sender may have written element we were reading. Copied data may be incoherent.
+    // We dropped the element we were trying to read, so increment *numDropped.
+    ++(*numDropped); 
+    return false;
+  }
+}
+
+bool queue_is_empty(recv_queue_t *recvQueue) {
+  return (recvQueue->queue->numSent == recvQueue->numRecv);
+}

--- a/apps/aadl-eventdata-direct-new/interfaces/queue.h
+++ b/apps/aadl-eventdata-direct-new/interfaces/queue.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+// Single sender multiple receiver Queue implementation for AADL Event Data
+// Ports. Every receiver receives the sent data (ie brodcast). The queue
+// operations are all non-blocking. The sender enqueue always succeeds. A
+// receiver dequeue can fail and drop data if the sender writes while the
+// receiver is reading. This situation is detected unless the sender gets
+// ahead of a receiver by more than COUNTER_MAX. Since COUNTER_MAX is typically
+// 2^64 (see counter.h), this is extremely unlikely. If it does happen the
+// only adverse effect is that the receiver will not detect all dropped
+// elements.
+
+#pragma once
+
+#include <counter.h> 
+#include <data.h>
+#include <stdbool.h>
+
+// Queue size must be an integer factor of the size for counter_t (an unsigned
+// integer type). Since we are using standard C unsigned integers for the
+// counter, picking a queue size that is a power of 2 is a good choice. We
+// could alternatively set the size of our counter to the largest possible
+// multiple of queue size. But then we would need to do our own modulo
+// operations on the counter rather than depending on c's unsigned integer
+// operations.
+//
+// Note: One cell in the queue is always considered dirty. Its the next
+// element to be written. Thus the queue can only contain QUEUE_SIZE-1
+// elements.
+#define QUEUE_SIZE 8
+
+// This is the type of the seL4 dataport (shared memory) that is shared by the
+// sender and all receivers. This type is referenced in the sender and receiver
+// CAmkES component definition files. The seL4 CAmkES runtime creates an
+// instance of this struct.
+typedef struct queue {
+  // Number of elements enqueued since the sender. The implementation depends
+  // on C's standard module behaviour for unsigned integers. The counter never
+  // overflows. It just wraps modulo the size of the counter type. The counter
+  // is typically very large (see counter.h), so this should happen very
+  // infrequently. Depending in C to initialize this to zero.
+  _Atomic counter_t numSent;
+  // Queue of elements of type data_t (see data.h) implemented as a ring buffer.
+  // No initialization necessary.
+  data_t elt[QUEUE_SIZE];
+} queue_t;
+
+//------------------------------------------------------------------------------
+// Sender API
+//
+// Could split this into separate header and source file since only sender
+// code needs this.
+
+// Initialize the queue. Sender must call this exactly once before any calls to queue_enqueue();
+void queue_init(queue_t *queue);
+
+// Enqueue data. This always succeeds and never blocks. Data is copied.
+void queue_enqueue(queue_t *queue, data_t *data);
+
+//------------------------------------------------------------------------------
+// Receiver API
+//
+// Could split this into separate header and source file since only receiver
+// code needs this.
+
+// Each receiver needs to create an instance of this.
+typedef struct recv_queue {
+  // Number of elements dequeued (or dropped) by a receiver. The implementation
+  // depends on C's standard module behaviour for unsigned integers. The
+  // counter never overflows. It just wraps modulo the size of the counter
+  // type. The counter is typically very large (see counter.h), so this should
+  // happen very infrequently.
+  counter_t numRecv;
+  // Pointer to the actual queue. This is the seL4 dataport (shared memory)
+  // that is shared by the sender and all receivers.
+  queue_t *queue;
+} recv_queue_t;
+
+// Each receiver must call this exactly once before any calls to other queue
+// API functions.
+void recv_queue_init(recv_queue_t *recvQueue, queue_t *queue);
+
+// Dequeue data. Never blocks but can fail if the sender writes at same
+// time. 
+
+// When successful returns true. The dequeued data will be copied to
+// *data. *numDropped will contain the number of elements that were dropped
+// since the last call to queue_dequeue().
+//
+// When queue is empty, returns false and *numDropped is zero. *data is left in
+// unspecified state.
+//
+// When dequeue fails due to possible write of data being read, returns false
+// and *numDropped will be >= 1 specifying the number of elements that were
+// dropped since the last call to queue_dequeue(). *data is left in
+// unspecified state.
+//
+// If the sender ever gets ahead of a receiver by more than COUNTER_MAX,
+// recv_dequeue will fail to count a multiple of COUNTER_MAX in
+// numDropped. Since COUNTER_MAX is very large (typically on the order of 2^64,
+// see counter.h), this is very unlikely.  If the sender is ever this far
+// ahead of a receiver the system is probably in a very bad state.
+bool queue_dequeue(recv_queue_t *recvQueue, counter_t *numDropped, data_t *data);
+
+// Is queue empty? If the queue is not empty, it will stay that way until the
+// receiver dequeues all data. If the queue is not empty you can make no
+// assumptions about how long it will stay empty.
+bool queue_is_empty(recv_queue_t *recvQueue); 


### PR DESCRIPTION
Ihor, I originally looked at your aadl-eventdata-direct code.  It did not preserve order of data at the receiver.  I realized that what I wanted was a generalization of the aadl-event-direct code, so rather than replace your code, I created a new directory (aadl-eventdata-direct-new).  I believe this is a complete replacement.  Feel free to remove your version and rename if you think it  would minimize confusion.